### PR TITLE
fix: agrega Playwright MCP y GitHub MCP al workspace

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,6 +3,14 @@
     "Figma Dev Mode MCP": {
       "url": "https://mcp.figma.com/mcp",
       "type": "http"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@microsoft/mcp-server-playwright"]
+    },
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "type": "http"
     }
   },
   "inputs": []

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/qa-add-mcp-config] Se agregaron Playwright MCP y GitHub MCP en `.vscode/mcp.json`.  
+  PR: [#39](https://github.com/martindebenedetti/Planix/pull/39) - @leanlex - Issue: #37
+
 - [fix/include-prompts-in-release] Se incorporan los archivos de prompts y comparativa de modelos de IA en la rama release/actividad-obligatoria-1.
   PR: [#15](https://github.com/martindebenedetti/Planix/pull/15) - @giann98 (Coordinador / DevOps)
 


### PR DESCRIPTION
## Resumen
Se actualiza `.vscode/mcp.json` para incorporar la configuración faltante de Playwright MCP y GitHub MCP en el workspace del proyecto.

## Cambios realizados
- Se mantiene la configuración existente de Figma Dev Mode MCP
- Se agrega Playwright MCP
- Se agrega GitHub MCP

## Motivo
Se corrige la observación realizada en la revisión de la Actividad Obligatoria N°2 respecto de la evidencia de configuración MCP en el repositorio.

## Issue asociado
Closes #37