### PR TITLE
fix: completa evidencia y checklist en spec-devops

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/devops-complete-spec-evidence] Se completó `spec-devops.md` con evidencia, decisiones sobre el mockup y checklist final.  
+  PR: [#41](https://github.com/martindebenedetti/Planix/pull/41) - @leanlex- Issue: #38
+
 - [fix/qa-add-mcp-config] Se agregaron Playwright MCP y GitHub MCP en `.vscode/mcp.json`.  
   PR: [#39](https://github.com/martindebenedetti/Planix/pull/39) - @leanlex - Issue: #37
 

--- a/docs/03-specs/actividad-obligatoria-2/spec-devops.md
+++ b/docs/03-specs/actividad-obligatoria-2/spec-devops.md
@@ -2,60 +2,62 @@
 
 ## Descripción
 
-Esta especificación técnica describe las tareas a realizar por el rol de **DevOps** en el marco de la **Actividad Obligatoria N°2**.
+Esta especificación técnica describe las tareas realizadas por el rol de **Coordinador / DevOps** en el marco de la **Actividad Obligatoria N°2**.
 
-Se aplica la metodología **Spec-Driven Development (SDD)**, donde esta especificación se redacta antes de ejecutar cualquier tarea de desarrollo.
+Se aplica la metodología **Spec-Driven Development (SDD)**, donde esta especificación se define como guía del trabajo del rol y se completa al cierre con la evidencia de las decisiones tomadas, revisiones realizadas y resultados obtenidos.
 
 ---
 
 ## ¿Qué se hará?
 
-Como responsable del rol **DevOps**, se implementarán las siguientes tareas:
+Como responsable del rol **DevOps**, se definieron e implementaron las siguientes tareas:
 
 1. **Definición del alcance del rol**
    - Coordinar el flujo de trabajo del repositorio utilizando Git y GitHub.
    - Supervisar la creación y revisión de Pull Requests del equipo.
-   - Garantizar que los cambios estén alineados con el `plan.md` y el mockup actualizado.
-   - Coordinar la creación de ramas `feature/` y `release/`.
+   - Garantizar que los cambios estuvieran alineados con el `plan.md` y el mockup actualizado.
+   - Coordinar la creación de ramas `feature/`, `develop` y `release/`.
 
 2. **Implementación de las tareas del rol**
    - Crear y gestionar ramas de trabajo para las funcionalidades de la Actividad 2.
    - Supervisar el proceso de revisión de código (Code Review) en las Pull Requests.
-   - Verificar que cada Pull Request tenga al menos una revisión antes del merge.
+   - Verificar que cada Pull Request tuviera al menos una revisión antes del merge.
    - Coordinar la integración de los cambios en la rama `develop`.
-   - Crear la rama de release correspondiente a la Actividad Obligatoria N°2.
+   - Crear la rama de `release` correspondiente a la Actividad Obligatoria N°2.
    - Configurar y verificar la publicación del sitio mediante GitHub Pages.
 
 3. **Documentación**
    - Registrar los cambios realizados en el archivo `changelog.md`.
    - Documentar las decisiones técnicas relacionadas con el flujo de trabajo del repositorio.
-   - Mantener actualizados los archivos `README.md` y `plan.md` cuando sea necesario.
+   - Mantener actualizados los archivos `README.md` y `plan.md` cuando fue necesario.
 
 ---
 
 ## ¿Por qué?
 
-La definición de esta especificación permite establecer claramente qué tareas realizará el rol DevOps dentro del proyecto, evitando ambigüedades y facilitando el trabajo colaborativo del equipo.
+La definición de esta especificación permitió establecer con claridad las tareas del rol DevOps dentro del proyecto, evitando ambigüedades y facilitando el trabajo colaborativo del equipo.
 
-Aplicar **Spec-Driven Development** permite que las decisiones técnicas se documenten antes de implementar cambios, mejorando la organización del proyecto y facilitando la revisión de Pull Requests.
+Aplicar **Spec-Driven Development** permitió documentar decisiones técnicas antes y durante la implementación, mejorando la organización del repositorio, la trazabilidad de las Pull Requests y la validación final de la release.
 
 ---
 
 ## Criterios de Aceptación
 
-- [ ] Las tareas del rol DevOps están claramente definidas.
-- [ ] Las decisiones técnicas se encuentran documentadas.
-- [ ] La implementación cumple con los objetivos establecidos en el plan del proyecto.
-- [ ] El trabajo se encuentra documentado y versionado en el repositorio.
-- [ ] Las Pull Requests del equipo fueron revisadas antes de ser mergeadas.
+- [x] Las tareas del rol DevOps están claramente definidas.
+- [x] Las decisiones técnicas se encuentran documentadas.
+- [x] La implementación cumple con los objetivos establecidos en el plan del proyecto.
+- [x] El trabajo se encuentra documentado y versionado en el repositorio.
+- [x] Las Pull Requests del equipo fueron revisadas antes de ser mergeadas.
 
 ---
 
 ## Responsabilidades Adicionales
 
 - Coordinar la integración de cambios entre las diferentes ramas del repositorio.
-- Verificar que el flujo de trabajo del proyecto se mantenga ordenado.
-- Colaborar con los demás roles para asegurar que los cambios sean consistentes con el mockup y el plan del proyecto.
+- Verificar que el flujo de trabajo del proyecto se mantuviera ordenado.
+- Colaborar con los demás roles para asegurar que los cambios fueran consistentes con el mockup y el plan del proyecto.
+- Validar que la rama de `release` se generara a partir de una base estable en `develop`.
+- Verificar que la publicación final en GitHub Pages reflejara el estado aprobado del proyecto.
 
 ---
 
@@ -65,15 +67,70 @@ Aplicar **Spec-Driven Development** permite que las decisiones técnicas se docu
   **Mitigación**: Utilizar una estructura clara de ramas (`feature/`, `develop`, `release/`).
 
 - **Riesgo**: Pull Requests sin revisión previa.  
-  **Mitigación**: Verificar que cada PR tenga al menos una revisión aprobada antes del merge.
+  **Mitigación**: Verificar que cada PR tuviera al menos una revisión aprobada antes del merge.
 
 - **Riesgo**: Inconsistencias entre el mockup, el plan del proyecto y la implementación.  
-  **Mitigación**: Realizar revisiones de código verificando coherencia con `plan.md` y el mockup del proyecto.
+  **Mitigación**: Realizar revisiones verificando coherencia con `plan.md`, `README.md` y el mockup del proyecto.
+
+- **Riesgo**: Publicar una release sin validación final del estado del repositorio.  
+  **Mitigación**: Confirmar que todas las features estuvieran integradas en `develop`, que QA hubiera finalizado las validaciones y que la release se generara luego de esa revisión.
 
 ---
 
-## Referencias
+## Decisiones Técnicas Tomadas
 
-- Plan maestro del proyecto (`plan.md`)
-- Documentación del repositorio (`README.md`)
-- Mockup del proyecto en Figma
+Durante la Actividad Obligatoria N°2 se tomaron las siguientes decisiones técnicas desde el rol DevOps:
+
+1. **Mantener el flujo de trabajo basado en ramas**
+   - Cada integrante trabajó en su propia rama `feature/`.
+   - Los cambios fueron integrados en `develop` mediante Pull Requests revisadas.
+   - La rama `release/actividad-obligatoria-2` se creó una vez consolidadas las features y validado el trabajo en `develop`.
+
+2. **Exigir revisión previa antes del merge**
+   - Se verificó que todas las Pull Requests del proyecto tuvieran al menos una revisión antes de ser mergeadas.
+   - Se utilizó el proceso de code review para detectar observaciones y solicitar ajustes antes de aprobar.
+
+3. **Mantener trazabilidad documental**
+   - Se registraron las contribuciones en `changelog.md`.
+   - Se mantuvo consistencia entre `README.md`, `plan.md`, specs técnicas y evidencias del proyecto.
+
+4. **Publicación de la release**
+   - Se resolvió publicar el sitio mediante GitHub Pages sobre la rama de release para exponer una versión estable y revisable del proyecto.
+
+---
+
+## Decisiones sobre el Mockup
+
+Desde la coordinación del repositorio, se verificó que la evolución visual definida en el mockup de la Actividad 2 quedara reflejada en la documentación y en la implementación.
+
+Las decisiones validadas fueron:
+
+- incorporación de una **paleta de colores** consistente con la nueva versión del diseño
+- uso de **tipografías** definidas en el mockup actualizado
+- ajuste de **espaciados, jerarquías visuales y estados de interacción**
+- actualización del `README.md` con enlace al mockup de A1 y A2
+- validación de que `plan.md` incluyera la sección **"Evolución del diseño (A2)"**
+
+También se verificó la existencia de la imagen exportada del mockup en:
+
+`docs/01-mockup/actividad-obligatoria-2/diseño-con-estilos.png`
+
+---
+
+## Prompts utilizados en Code Reviews con Copilot Agent
+
+A continuación se documenta el uso de Copilot Agent como asistencia para revisiones de Pull Requests del equipo.
+
+### Prompt base utilizado
+
+```text
+Revisá esta Pull Request teniendo en cuenta:
+1. consistencia con plan.md
+2. consistencia con el mockup actualizado de la Actividad 2
+3. cumplimiento del rol asignado
+4. claridad de la documentación técnica
+5. presencia de criterios de aceptación verificables
+6. estructura correcta de ramas, commits y changelog
+7. detección de errores, omisiones o mejoras necesarias
+
+Indicá hallazgos concretos, priorizados, y señalá si corresponde aprobar, comentar o pedir cambios.


### PR DESCRIPTION
## Resumen
Se actualiza `spec-devops.md` para completar la evidencia del rol Coordinador / DevOps en la Actividad Obligatoria N°2.

## Cambios realizados
- Se documentan decisiones técnicas tomadas durante la actividad
- Se agregan decisiones sobre el mockup
- Se incorporan referencias a prompts usados en code reviews con Copilot Agent
- Se completan los criterios de aceptación
- Se agrega evidencia de cierre del trabajo realizado

## Motivo
Se corrige la observación realizada en la revisión de la Actividad Obligatoria N°2 sobre la falta de evidencia explícita en `spec-devops.md`.

## Issues asociados
Closes #38