### PR TITLE
fix: agrega issue retroactiva del mockup en changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [feature/dev-frontend-css-add-styles] Creación del archivo spec.frontend.md y en base a este archivo se crearon los archivos css/styles.css y css/components.css. PR: [#27](https://github.com/martindebenedetti/Planix/pull/27) - @martindebenedetti (Desarrollador Frontend) - Issue: #21
 
 - [feature/mockup-actividad-2] Mockup actualizado con estilos visuales y actualización de README y plan.md  
-  PR: [#26](https://github.com/martindebenedetti/Planix/pull/26) - @giann98 (Coordinador / DevOps)
+  PR: [#26](https://github.com/martindebenedetti/Planix/pull/26) - @giann98 (Coordinador / DevOps) - Issue: #42
 
 ---
 


### PR DESCRIPTION
## Resumen
Se actualiza `changelog.md` para incorporar la issue retroactiva asociada a la tarea de mockup de la Actividad Obligatoria N°2.

## Cambios realizados
- Se agrega la referencia a la issue del mockup en la entrada correspondiente a PR #26
- Se deja trazabilidad de la vinculación retroactiva de esa tarea

## Motivo
Se corrige la observación sobre `changelog.md` y la falta de issue vinculada en la tarea de mockup.

Related to #42 