### PR TITLE
fix: ajusta padding del gantt segun mockup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/rc4-gantt-padding-mockup] Se ajustó el padding del área Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.  
+  PR: [#XX](LINK) - @leanlex
+
 - [fix/devops-complete-spec-evidence] Se completó `spec-devops.md` con evidencia, decisiones sobre el mockup y checklist final.  
   PR: [#41](https://github.com/martindebenedetti/Planix/pull/41) - @leanlex- Issue: #38
 

--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/rc4-gantt-padding-mockup] Se ajustó el padding del área Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.  
-  PR: [#XX](LINK) - @leanlex
+  PR: [#44](https://github.com/martindebenedetti/Planix/pull/44) - @leanlex
 
 - [fix/devops-complete-spec-evidence] Se completó `spec-devops.md` con evidencia, decisiones sobre el mockup y checklist final.  
   PR: [#41](https://github.com/martindebenedetti/Planix/pull/41) - @leanlex- Issue: #38

--- a/css/styles.css
+++ b/css/styles.css
@@ -659,17 +659,19 @@ main[role="main"] {
    de una sola columna cada uno. Los th de meses (scope="colgroup")
    NO se tocan aquí: su ancho lo determinan las columnas subyacentes. */
 #tabla-gantt td:nth-child(n+8) {
-  width:     var(--gantt-col-width);
-  min-width: var(--gantt-col-width);
-  max-width: var(--gantt-col-width);
+  width:      var(--gantt-col-width);
+  min-width:  var(--gantt-col-width);
+  max-width:  var(--gantt-col-width);
+  padding:    var(--space-3) var(--space-4);
 }
 
 /* Fila de semanas (S9–S18): todos sus th son de una sola columna.
    Definir el ancho aquí fija cada columna del Gantt con table-layout:fixed. */
 #tabla-gantt thead tr:nth-child(2) th {
-  width:     var(--gantt-col-width);
-  min-width: var(--gantt-col-width);
-  max-width: var(--gantt-col-width);
+  width:      var(--gantt-col-width);
+  min-width:  var(--gantt-col-width);
+  max-width:  var(--gantt-col-width);
+  padding:    var(--space-3) var(--space-4);
 }
 
 /* ── Encabezados de mes (MARZO / ABRIL / MAYO) ──
@@ -686,6 +688,7 @@ main[role="main"] {
   letter-spacing:   0.08em;
   text-transform:   uppercase;
   text-align:       center;
+  padding:          var(--space-3) var(--space-4);
   border-bottom:    2px solid var(--color-primary);
 }
 


### PR DESCRIPTION
## Resumen
Se ajusta el padding del área Gantt para alinearlo mejor con el mockup de la Actividad Obligatoria N°2.

## Cambios realizados
- Se incrementa el padding en las celdas del Gantt
- Se ajusta el padding de la fila de semanas
- Se ajusta el padding de los encabezados de mes
- Se actualiza `changelog.md` con la corrección

## Motivo
Se corrige el RC4 de la PR #36: Gantt padding comprimido vs mockup.