### PR TITLE
fix: agrega borde visible a toolbar-btn inactivo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/rc5-toolbar-btn-inactive-border] Se agregó borde visible al estado inactivo de `.toolbar-btn` para mejorar la consistencia con el mockup.  
-  PR: [#45](https://github.com/martindebenedetti/Planix/pull/45) - @leanlex
+  PR: [#46](https://github.com/martindebenedetti/Planix/pull/46) - @leanlex
 
 - [fix/rc4-gantt-padding-mockup] Se ajustó el padding del área Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.  
   PR: [#44](https://github.com/martindebenedetti/Planix/pull/44) - @leanlex

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/rc5-toolbar-btn-inactive-border] Se agregó borde visible al estado inactivo de `.toolbar-btn` para mejorar la consistencia con el mockup.  
+  PR: pendiente - @leanlex
+
 - [fix/rc4-gantt-padding-mockup] Se ajustó el padding del área Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.  
   PR: [#44](https://github.com/martindebenedetti/Planix/pull/44) - @leanlex
 

--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/rc5-toolbar-btn-inactive-border] Se agregó borde visible al estado inactivo de `.toolbar-btn` para mejorar la consistencia con el mockup.  
-  PR: pendiente - @leanlex
+  PR: [#45](https://github.com/martindebenedetti/Planix/pull/45) - @leanlex
 
 - [fix/rc4-gantt-padding-mockup] Se ajustó el padding del área Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.  
   PR: [#44](https://github.com/martindebenedetti/Planix/pull/44) - @leanlex

--- a/css/components.css
+++ b/css/components.css
@@ -33,24 +33,27 @@
   font-size:       var(--font-size-sm);
   font-weight:     var(--font-weight-medium);
   color:           var(--color-slate-600);
-  background:      transparent;
-  border:          1px solid transparent;
+  background:      var(--color-bg-white);
+  border:          1px solid var(--color-border);
   border-radius:   var(--radius-md);
   cursor:          pointer;
   white-space:     nowrap;
   transition:      background-color var(--transition-fast),
                    color            var(--transition-fast),
-                   border-color     var(--transition-fast);
+                   border-color     var(--transition-fast),
+                   box-shadow       var(--transition-fast);
 }
 
 .toolbar-btn:hover {
   background:   var(--color-slate-100);
   color:        var(--color-slate-800);
+  border-color: var(--color-slate-300);
 }
 
 .toolbar-btn:focus-visible {
-  outline:      2px solid var(--color-primary);
+  outline:        2px solid var(--color-primary);
   outline-offset: 2px;
+  border-color:   var(--color-primary);
 }
 
 .toolbar-btn:active {


### PR DESCRIPTION
## Resumen
Se ajusta el estilo de `.toolbar-btn` para que el estado inactivo tenga un borde visible y se alinee mejor con el mockup de la Actividad Obligatoria N°2.

## Cambios realizados
- Se agrega borde visible en estado inactivo
- Se mantienen diferenciados los estados hover, focus y activo
- Se actualiza `changelog.md` con la corrección

## Motivo
Se corrige el RC5 de la PR #36: `.toolbar-btn` sin borde visible en estado inactivo.