### PR TITLE
fix: diferencia color de filas de grupo y elimina regla duplicada

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/rc6-group-row-color-duplicate-rule] Se diferenció el color de las filas de grupo respecto del hover y se eliminó una regla duplicada en `css/styles.css`.  
-  PR: pendiente - @leanlex
+  PR: [#47](https://github.com/martindebenedetti/Planix/pull/47) - @leanlex
 
 - [fix/rc5-toolbar-btn-inactive-border] Se agregó borde visible al estado inactivo de `.toolbar-btn` para mejorar la consistencia con el mockup.  
   PR: [#46](https://github.com/martindebenedetti/Planix/pull/46) - @leanlex

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/rc6-group-row-color-duplicate-rule] Se diferenció el color de las filas de grupo respecto del hover y se eliminó una regla duplicada en `css/styles.css`.  
+  PR: pendiente - @leanlex
+
 - [fix/rc5-toolbar-btn-inactive-border] Se agregó borde visible al estado inactivo de `.toolbar-btn` para mejorar la consistencia con el mockup.  
   PR: [#46](https://github.com/martindebenedetti/Planix/pull/46) - @leanlex
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -713,20 +713,15 @@ main[role="main"] {
 }
 
 /* Filas de grupo (PLANIFICACIÓN, DISEÑO, etc.):
-   fondo oscuro, texto bold, sin efecto hover para distinguirlas */
+   fondo diferenciado, texto bold y hover neutro para distinguirlas */
 #tabla-gantt tbody tr[aria-label*="Grupo"] td {
-  background-color: var(--color-primary-light);
-  color: var(--color-slate-800);
-  font-weight: var(--font-weight-semibold);
+  background-color: var(--color-slate-100);
+  color:            var(--color-slate-800);
+  font-weight:      var(--font-weight-semibold);
 }
 
 #tabla-gantt tbody tr[aria-label*="Grupo"]:hover td {
-  background-color: #d6e9ff; /* anula el hover de filas normales */
-}
-
-/* Hover en filas normales */
-#tabla-gantt tbody tr:hover td {
-  background-color: var(--color-primary-light);
+  background-color: var(--color-slate-100);
 }
 
 /* Barras del diagrama de Gantt: ver .gantt-bar / .gantt-bar__fill en components.css */


### PR DESCRIPTION
## Resumen
Se ajustan los estilos de las filas de grupo en la tabla Gantt para diferenciarlas del estado hover y se elimina una regla duplicada en `css/styles.css`.

## Cambios realizados
- Se cambia el color de fondo de las filas de grupo
- Se corrige el hover de las filas de grupo
- Se elimina una regla duplicada de hover
- Se actualiza `changelog.md` con la corrección

## Motivo
Se corrige el RC6 de la PR #36: filas de grupo con mismo color que hover y regla duplicada.