### PR TITLE
fix: agrega badge HOY en columna S16

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/rc7-badge-hoy-s16] Se agregó el badge "HOY" en la columna S16 del encabezado del Gantt.  
+  PR: pendiente - @leanlex
+
 - [fix/rc6-group-row-color-duplicate-rule] Se diferenció el color de las filas de grupo respecto del hover y se eliminó una regla duplicada en `css/styles.css`.  
   PR: [#47](https://github.com/martindebenedetti/Planix/pull/47) - @leanlex
 

--- a/css/components.css
+++ b/css/components.css
@@ -748,6 +748,26 @@ a.btn--disabled {
   color:      var(--color-slate-600);
 }
 
+.gantt-week-header {
+  display:         flex;
+  flex-direction:  column;
+  align-items:     center;
+  justify-content: center;
+  gap:             var(--space-1);
+}
+
+.gantt-week-label {
+  line-height: 1;
+}
+
+.badge--today {
+  padding:        1px var(--space-2);
+  font-size:      var(--font-size-xs);
+  font-weight:    var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 /* ── Barra de progreso componente ──
    Versión portable de la barra de progreso del header.
    Contenedor de bloque + relleno interno absoluto. */

--- a/index.html
+++ b/index.html
@@ -230,7 +230,12 @@
                         <th scope="col" aria-label="Semana 13">S13</th>
                         <th scope="col" aria-label="Semana 14">S14</th>
                         <th scope="col" aria-label="Semana 15">S15</th>
-                        <th scope="col" aria-label="Semana 16">S16</th>
+                        <th scope="col" aria-label="Semana 16, semana actual">
+                            <div class="gantt-week-header">
+                                <span class="gantt-week-label">S16</span>
+                                <span class="badge badge--primary badge--today" aria-label="Hoy">HOY</span>
+                            </div>
+                        </th>
                         <th scope="col" aria-label="Semana 17">S17</th>
                         <th scope="col" aria-label="Semana 18">S18</th>
                     </tr>


### PR DESCRIPTION
## Resumen
Se agrega el badge "HOY" en la columna S16 del encabezado del Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.

## Cambios realizados
- Se actualiza `index.html` para incorporar el badge en S16
- Se agrega soporte visual en `css/components.css`
- Se actualiza `changelog.md` con la corrección

## Motivo
Se corrige el RC7 de la PR #36: badge "HOY" ausente en columna S16.