### PR TITLE
fix: agrega sidebar iconografico

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/rc8-sidebar-icons] Se agregó una sidebar iconográfica en la estructura principal del planificador y sus estilos asociados en `css/styles.css`.  
-  PR: pendiente - @leanlex
+  PR: [#50](https://github.com/martindebenedetti/Planix/pull/50) - @leanlex
 
 - [fix/rc7-changelog-pr-number] Se corrigió la referencia de la PR en `changelog.md` para el fix RC7.  
   PR: [#49](https://github.com/martindebenedetti/Planix/pull/49) - @leanlex

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/rc8-sidebar-icons] Se agregó una sidebar iconográfica en la estructura principal del planificador y sus estilos asociados en `css/styles.css`.  
+  PR: pendiente - @leanlex
+
 - [fix/rc7-changelog-pr-number] Se corrigió la referencia de la PR en `changelog.md` para el fix RC7.  
   PR: [#49](https://github.com/martindebenedetti/Planix/pull/49) - @leanlex
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -532,6 +532,65 @@ main[role="main"] {
   flex:           1;
   overflow:       hidden; /* el scroll interno lo maneja el contenedor de la tabla */
   min-height:     0;      /* necesario en Firefox para que flex-1 funcione correctamente */
+  position:       relative;
+}
+
+main[role="main"] > :not(.main-sidebar) {
+  margin-left: 56px;
+}
+
+.main-sidebar {
+  position:         absolute;
+  top:              0;
+  left:             0;
+  bottom:           0;
+  width:            56px;
+  display:          flex;
+  flex-direction:   column;
+  align-items:      center;
+  gap:              var(--space-2);
+  padding:          var(--space-4) var(--space-2);
+  background-color: var(--color-bg-white);
+  border-right:     1px solid var(--color-border);
+  z-index:          5;
+}
+
+.sidebar-icon-btn {
+  display:          inline-flex;
+  align-items:      center;
+  justify-content:  center;
+  width:            36px;
+  height:           36px;
+  border:           1px solid var(--color-border);
+  border-radius:    var(--radius-md);
+  background-color: var(--color-bg-white);
+  color:            var(--color-slate-600);
+  transition:       background-color var(--transition-fast),
+                    color var(--transition-fast),
+                    border-color var(--transition-fast),
+                    box-shadow var(--transition-fast);
+}
+
+.sidebar-icon-btn:hover {
+  background-color: var(--color-slate-100);
+  color:            var(--color-slate-800);
+  border-color:     var(--color-slate-300);
+}
+
+.sidebar-icon-btn:focus-visible {
+  outline:        2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.sidebar-icon-btn--active {
+  background-color: var(--color-primary);
+  border-color:     var(--color-primary);
+  color:            var(--color-bg-white);
+}
+
+.sidebar-icon-btn--active:hover {
+  background-color: var(--color-primary-dark);
+  border-color:     var(--color-primary-dark);
 }
 
 /* ── SECCIÓN NUEVA TAREA ──

--- a/index.html
+++ b/index.html
@@ -17,10 +17,7 @@
     <!-- TODO: CSS - Soporte dark mode -->
 <link rel="stylesheet" href="css/styles.css">
 <link rel="stylesheet" href="css/components.css">
-
 <link rel="stylesheet" href="css/responsive.css">
-
-
 </head>
 <body>
 
@@ -104,6 +101,24 @@
     ============================================================ -->
     <main role="main" aria-label="Contenido principal del planificador">
 
+        <aside class="main-sidebar" aria-label="Barra lateral de accesos rápidos">
+            <button type="button" class="sidebar-icon-btn sidebar-icon-btn--active" aria-label="Vista Gantt activa">
+                <span aria-hidden="true">▦</span>
+            </button>
+            <button type="button" class="sidebar-icon-btn" aria-label="Calendario">
+                <span aria-hidden="true">🗓</span>
+            </button>
+            <button type="button" class="sidebar-icon-btn" aria-label="Hitos">
+                <span aria-hidden="true">◆</span>
+            </button>
+            <button type="button" class="sidebar-icon-btn" aria-label="Responsables">
+                <span aria-hidden="true">👥</span>
+            </button>
+            <button type="button" class="sidebar-icon-btn" aria-label="Configuración">
+                <span aria-hidden="true">⚙</span>
+            </button>
+        </aside>
+
         <!-- ========================================================
              SECCIÓN INTRODUCTORIA: descripción del planificador
              TODO: CSS - Padding, tipografía, fondo sutil
@@ -157,7 +172,7 @@
              TODO: CSS - Fondo blanco, borde inferior, padding, shrink-0
              TODO: CSS - Campos en fila horizontal con flex y gap
         ======================================================== --> 
-       
+
         <section id="nueva-tarea" aria-labelledby="titulo-nueva-tarea">
             <h2 id="titulo-nueva-tarea">Nueva tarea</h2>
 
@@ -186,11 +201,11 @@
                     <label for="avance" class="form-label">% Avance:</label>
                     <input type="number" id="avance" name="avance" class="form-input" min="0" max="100" value="0">
                 </div>
-                
+
                 <button type="submit" class="btn btn-primary" aria-label="Agregar nueva tarea">+ Agregar tarea</button>
             </form>
         </section>
-        
+
         <!-- ========================================================
              TABLA GANTT UNIFICADA
              Cada fila tiene: datos de tarea (izquierda) + barra (derecha)
@@ -210,7 +225,7 @@
                     <tr>
                         <th scope="col" rowspan="2" aria-label="Identificador">ID</th>
                         <th scope="col" rowspan="2" aria-label="Nombre de la tarea">Nombre Tarea</th>
-                        
+
                         <th scope="col" rowspan="2" aria-label="Duración">Duración</th>
                         <th scope="col" rowspan="2" aria-label="Fecha de inicio">f_inicio</th>
                         <th scope="col" rowspan="2" aria-label="Fecha de fin">f_fin</th>
@@ -262,7 +277,7 @@
                             <div class="gantt-bar__fill" style="width: 100%;" aria-hidden="true"></div>
                                 <span class="gantt-bar__label">100%</span>
                         </div>
-                        
+
                         </td>
                         <td colspan="7" aria-hidden="true"></td>
                     </tr>


### PR DESCRIPTION
## Resumen
Se agrega una sidebar iconográfica en la estructura principal del planificador para alinearlo mejor con el mockup de la Actividad Obligatoria N°2.

## Cambios realizados
- Se actualiza `index.html` con la sidebar de accesos rápidos
- Se agregan estilos en `css/styles.css` para su disposición y estados visuales
- Se actualiza `changelog.md` con la corrección

## Motivo
Se corrige el RC8 de la PR #36: sidebar iconográfico ausente.