### PR TITLE
fix: Limpiar changelog, eliminando backport y duplicado de A2 en A1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,7 +26,7 @@ PR: [#58](https://github.com/martindebenedetti/Planix/pull/58) - @giann98 (Desar
 ### Fixed
 
 - [fix/limpieza-changelog-RC02-RC03] Corrección del changelog, eliminación duplicado y backport RC02 y RC03. 
-PR: [#]() - @giann98 (Coordinador / DevOps) 
+PR: [#66](https://github.com/martindebenedetti/Planix/pull/66) - @giann98 (Coordinador / DevOps) 
 
 - [fix/sidebar-responsive1] Corrección del sidebar en mobile.
 PR: [#62](https://github.com/martindebenedetti/Planix/pull/62) - @giann98 (Frontend/Bootstrap) - Issue: #55

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ## [Unreleased]
 
+## [Release Primer Parcial] - 2026-04-22
+
 ### Added
 
 - [feature/coord-devops-update-doc-project] Actualización de `spec-devops.md`, `README.md` y del mockup del Primer Parcial (`docs/01-mockup/disenio-bootstrap.png`), además de coordinación de code reviews asistidas por IA sobre las PRs del equipo y seguimiento de issues en GitHub Projects.  
@@ -22,6 +24,9 @@ PR: [#64](https://github.com/martindebenedetti/Planix/pull/64) - @giann98 (Desar
 PR: [#58](https://github.com/martindebenedetti/Planix/pull/58) - @giann98 (Desarrollador Frontend/Bootstrap) - Issue: #56
 
 ### Fixed
+
+- [fix/limpieza-changelog-RC02-RC03] Corrección del changelog, eliminación duplicado y backport RC02 y RC03. 
+PR: [#]() - @giann98 (Coordinador / DevOps) 
 
 - [fix/sidebar-responsive1] Corrección del sidebar en mobile.
 PR: [#62](https://github.com/martindebenedetti/Planix/pull/62) - @giann98 (Frontend/Bootstrap) - Issue: #55
@@ -45,9 +50,6 @@ PR: [#62](https://github.com/martindebenedetti/Planix/pull/62) - @giann98 (Front
   PR: [#26](https://github.com/martindebenedetti/Planix/pull/26) - @giann98 (Coordinador / DevOps) - Issue: #42
 
 ### Fixed
-
-- [backport/release-actividad-obligatoria-2] Backport: release actividad obligatoria 2 hacia develop.
-  PR: [#52](https://github.com/martindebenedetti/Planix/pull/52) - @leanberro (Coordinador / DevOps).
 
 - [fix/remove-unused-gitkeep-files] Se eliminaron archivos `.gitkeep` innecesarios en carpetas de capturas que ya contienen archivos reales.  
   PR: [#51](https://github.com/martindebenedetti/Planix/pull/51) - @leanlex (Coordinador / DevOps).
@@ -107,36 +109,6 @@ PR: [#62](https://github.com/martindebenedetti/Planix/pull/62) - @giann98 (Front
 
 ### Fixed
 
-- [backport/release-actividad-obligatoria-2] Backport: release actividad obligatoria 2 hacia develop.
-  PR: [#52](https://github.com/martindebenedetti/Planix/pull/52) - @leanberro (Coordinador / DevOps).
-
-- [fix/remove-unused-gitkeep-files] Se eliminaron archivos `.gitkeep` innecesarios en carpetas de capturas que ya contienen archivos reales.  
-  PR: [#51](https://github.com/martindebenedetti/Planix/pull/51) - @leanlex (Coordinador / DevOps).
-
-- [fix/rc8-sidebar-icons] Se agregó una sidebar iconográfica en la estructura principal del planificador y sus estilos asociados en `css/styles.css`.  
-  PR: [#50](https://github.com/martindebenedetti/Planix/pull/50) - @leanlex (Coordinador / DevOps).
-
-- [fix/rc7-changelog-pr-number] Se corrigió la referencia de la PR en `changelog.md` para el fix RC7.  
-  PR: [#49](https://github.com/martindebenedetti/Planix/pull/49) - @leanlex (Coordinador / DevOps).
-
-- [fix/rc7-badge-hoy-s16] Se agregó el badge "HOY" en la columna S16 del encabezado del Gantt.  
-  PR: [#48](https://github.com/martindebenedetti/Planix/pull/48) - @leanlex (Coordinador / DevOps).
-
-- [fix/rc6-group-row-color-duplicate-rule] Se diferenció el color de las filas de grupo respecto del hover y se eliminó una regla duplicada en `css/styles.css`.  
-  PR: [#47](https://github.com/martindebenedetti/Planix/pull/47) - @leanlex (Coordinador / DevOps).
-
-- [fix/rc5-toolbar-btn-inactive-border] Se agregó borde visible al estado inactivo de `.toolbar-btn` para mejorar la consistencia con el mockup.  
-  PR: [#46](https://github.com/martindebenedetti/Planix/pull/46) - @leanlex (Coordinador / DevOps).
-
-- [fix/rc4-gantt-padding-mockup] Se ajustó el padding del área Gantt para alinearlo con el mockup de la Actividad Obligatoria N°2.  
-  PR: [#44](https://github.com/martindebenedetti/Planix/pull/44) - @leanlex (Coordinador / DevOps).
-
-- [fix/devops-complete-spec-evidence] Se completó `spec-devops.md` con evidencia, decisiones sobre el mockup y checklist final.  
-  PR: [#41](https://github.com/martindebenedetti/Planix/pull/41) - @leanlex- Issue: #38 (Coordinador / DevOps).
-
-- [fix/qa-add-mcp-config] Se agregaron Playwright MCP y GitHub MCP en `.vscode/mcp.json`.  
-  PR: [#39](https://github.com/martindebenedetti/Planix/pull/39) - @leanlex - Issue: #37 (Coordinador / DevOps).
-
 - [fix/include-prompts-in-release] Se incorporan los archivos de prompts y comparativa de modelos de IA en la rama release/actividad-obligatoria-1.
   PR: [#15](https://github.com/martindebenedetti/Planix/pull/15) - @giann98 (Coordinador / DevOps)
 
@@ -168,8 +140,5 @@ PR: [#62](https://github.com/martindebenedetti/Planix/pull/62) - @giann98 (Front
 
 - [fix/formato-changelog-correcciones] Corrección de formato en entradas [Fixed] del changelog.
   PR: [#24](https://github.com/martindebenedetti/Planix/pull/24) - @martindebenedetti (Coordinador / DevOps)
-
-- [backport/release-actividad-obligatoria-1] Backport: release actividad obligatoria 1 hacia develop.
-  PR: [#25](https://github.com/martindebenedetti/Planix/pull/25) - @giann98 (Coordinador / DevOps).
 
 ---


### PR DESCRIPTION
Se realizan cambios en changelog, eliminando las entradas de backport y las duplicadas en A1 pertenecientes a A2