### PR TITLE
RC-16: eliminar sección #descripcion no contemplada en el Figma

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,55 +128,7 @@
             </button>
         </aside>
 
-        <!-- ========================================================
-             SECCIÓN INTRODUCTORIA: descripción del planificador
-             TODO: CSS - Padding, tipografía, fondo sutil
-        ======================================================== -->
         <div class="col main-content">
-        <section id="descripcion" class="mb-4" aria-labelledby="titulo-descripcion">
-            <h2 id="titulo-descripcion">¿Qué es este planificador?</h2>
-
-            <p>
-                Este planificador de tareas permite organizar y visualizar el cronograma
-                de un proyecto mediante un <strong>diagrama de Gantt</strong>. Cada tarea
-                se representa como una barra horizontal que indica su duración, fechas de
-                inicio y fin, y porcentaje de avance.
-            </p>
-
-            <p>
-                La herramienta está inspirada en aplicaciones como
-                <a href="https://www.microsoft.com/es-ar/microsoft-365/project/project-management-software"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   aria-label="Sitio oficial de Microsoft Project">Microsoft Project</a>
-                y está desarrollada como proyecto académico en el marco de
-                <a href="https://github.com/martindebenedetti/Planix"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   aria-label="Repositorio del proyecto en GitHub">Programación Web I — UCES 2026</a>.
-            </p>
-
-            <p>
-                Para comenzar, agregá una nueva tarea usando el formulario de abajo,
-                completando el nombre, responsable, fechas y porcentaje de avance.
-                Las tareas se verán reflejadas automáticamente en el diagrama de Gantt.
-                <!-- TODO: JS - Actualizar este párrafo dinámicamente cuando se agreguen tareas -->
-            </p>
-
-
-            <!-- Navegación interna rápida -->
-            <!-- TODO: CSS - Estilo de links internos como chips o tabs -->
-            <nav aria-label="Navegación interna de secciones">
-                <ul>
-                    <li><a href="#nueva-tarea" aria-label="Ir al formulario de nueva tarea">+ Nueva tarea</a></li>
-                    <li><a href="#tabla-gantt" aria-label="Ir a la tabla del diagrama de Gantt">Ver diagrama</a></li>
-                    <li><a href="https://es.wikipedia.org/wiki/Diagrama_de_Gantt"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           aria-label="Qué es un diagrama de Gantt - Wikipedia">¿Qué es un Gantt?</a></li>
-                </ul>
-            </nav>
-        </section>
         <!-- ========================================================
              INFORMACIÓN DEL PROYECTO (Acordeón nativo)
         ======================================================== -->


### PR DESCRIPTION
La sección introductoria '¿Qué es este planificador?' fue agregada sin respaldo en el diseño. El Figma (docs/01-mockup/disenio-bootstrap.png) muestra la vista Gantt directamente como pantalla principal, sin sección introductoria previa.