### PR TITLE
[RC Coordinador] Cierre de RC-11 Bootstrap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/coord-devops-cierre-rc11-bootstrap] Documenta cierre de RC-11 e integración final de TC-7 y TC-8 en la release del Primer Parcial. PR: #XX — @leanlex — Ayudando al rol(Coordinador / DevOps)
+
 - [fix/RC9-RC12-frontend-spec] Se deja evidencia que se utiliza Figma MCP para analizar mockup y se realiza review sobre una PR — PR#75 — @giann98 (Coordinador / DevOps)
 
 - [fix/RC-13-Recrear-feature-hmtl-avanzado] Se documenta que los commits se encuentran dentro del feature de html-avanzado — PR#74 — @giann98 (Coordinador / DevOps) 

--- a/docs/03-specs/primer-parcial/spec-componentes-bootstrap.md
+++ b/docs/03-specs/primer-parcial/spec-componentes-bootstrap.md
@@ -123,3 +123,32 @@ Todos estos puntos fueron corregidos en diferentes ramas fix creadas.
 
 - Bootstrap Documentation
 - Documentación del repositorio Planix
+
+---
+
+## AT CLOSE — Corrección RC-11: evidencia Playwright MCP
+
+Luego de la devolución docente, se completó la documentación pendiente correspondiente al testing de los componentes Bootstrap avanzados.
+
+### Test cases integrados
+
+| Test Case | Componente | Herramienta | Evidencia | Estado |
+|---|---|---|---|---|
+| TC-7 | Modal compartir enlace Bootstrap | Playwright MCP | `docs/04-testing/capturas/tc-7/` | PASS |
+| TC-8 | Offcanvas de ayuda Bootstrap | Playwright MCP | `docs/04-testing/capturas/tc-8/` | PASS |
+
+### Archivos verificados
+
+- `docs/04-testing/test-case-7.md`
+- `docs/04-testing/test-case-8.md`
+- `docs/04-testing/capturas/tc-7/`
+- `docs/04-testing/capturas/tc-8/`
+- `docs/04-testing/testing-doc.md`
+
+### Resultado
+
+Se considera corregida la observación RC-11 del rol Especialista en Componentes Bootstrap, ya que los test cases requeridos fueron incorporados, se agregó evidencia de ejecución y se actualizó el índice general de testing.
+
+### Observación
+
+La mención previa a la ausencia inicial de evidencia explícita de Playwright MCP queda documentada como antecedente de revisión. La evidencia actual se encuentra integrada en los test cases y carpetas correspondientes.

--- a/docs/03-specs/primer-parcial/spec-devops.md
+++ b/docs/03-specs/primer-parcial/spec-devops.md
@@ -502,3 +502,34 @@ A partir del análisis obtenido mediante Figma MCP, se documentan las siguientes
 
 Evidencia incorporada para responder a RC-07.
 
+---
+
+## AT CLOSE — Cierre de RC-11 e integración final de correcciones
+
+Luego de la integración de la corrección del rol Especialista en Componentes Bootstrap, se verificó que los entregables pendientes de RC-11 ya se encuentran presentes en la rama `release/primer-parcial`.
+
+### Verificación realizada
+
+| Entregable | Estado |
+|---|---|
+| `docs/04-testing/test-case-7.md` | Integrado |
+| `docs/04-testing/test-case-8.md` | Integrado |
+| `docs/04-testing/capturas/tc-7/` | Integrado |
+| `docs/04-testing/capturas/tc-8/` | Integrado |
+| `docs/03-specs/primer-parcial/spec-componentes-bootstrap.md` | Actualizado |
+| `docs/04-testing/testing-doc.md` | Actualizado |
+| `changelog.md` | Actualizado |
+
+### Decisión como Coordinador/DevOps
+
+Se considera integrada la corrección correspondiente a RC-11, dejando documentada la evidencia de testing de los componentes Bootstrap y la trazabilidad mediante rama `fix/`, Pull Request, changelog y archivos de testing.
+
+### Estado final de correcciones coordinadas
+
+| RC / Observación | Estado final |
+|---|---|
+| RC-05 / RC-06 — Body de PR release | Corregido |
+| RC-07 — Evidencia Figma MCP | Corregido |
+| RC-11 — TC-7 y TC-8 Componentes Bootstrap | Corregido |
+| RC-14 / RC-15 — HTML avanzado y testing | Corregido |
+| Changelog A2 — backport / em dash | Corregido |


### PR DESCRIPTION
## Descripción

Esta PR documenta el cierre de RC-11 luego de la integración de los test cases TC-7 y TC-8 correspondientes al rol Especialista en Componentes Bootstrap.

## Cambios realizados

- Se verificó la existencia de `test-case-7.md` y `test-case-8.md`.
- Se verificaron las carpetas de evidencia `capturas/tc-7/` y `capturas/tc-8/`.
- Se actualizó `spec-componentes-bootstrap.md` con evidencia de Playwright MCP.
- Se actualizó `spec-devops.md` con el cierre de RC-11.
- Se actualizó `changelog.md`.

## Checklist

- [x] La rama parte desde `release/primer-parcial`.
- [x] TC-7 y TC-8 existen.
- [x] Las evidencias de testing están integradas.
- [x] Se documentó Playwright MCP en el spec del rol.
- [x] Se documentó el cierre en `spec-devops.md`.
- [x] Se actualizó el changelog.