### PR TITLE
fix(rc3): cerrar items del checklist en spec-tester.md

### DIFF
--- a/docs/03-specs/actividad-obligatoria-3/spec-tester.md
+++ b/docs/03-specs/actividad-obligatoria-3/spec-tester.md
@@ -70,8 +70,8 @@ de ejecución.
 - [x] Archivo `js/test/testing-doc.md` documentado
 - [x] Tests ejecutados exitosamente mediante Playwright MCP
 - [x] Capturas PASS/FAIL obtenidas mediante Playwright MCP
-- [ ] Bugs encontrados reportados como issues en GitHub
-- [ ] Coordinación realizada con el Desarrollador JavaScript para mejorar testabilidad
+- [x] Bugs encontrados reportados como issues en GitHub (no se detectaron bugs — 18/18 specs pasando, sin issues a reportar)
+- [x] Coordinación realizada con el Desarrollador JavaScript para mejorar testabilidad (no fue necesaria: el código de `script.js` resultó directamente testeable, 18/18 specs pasando con 0 fallos)
 
 ---
 


### PR DESCRIPTION
Se cierran los dos items sin marcar del checklist de criterios de aceptacion en spec-tester.md:

- Bugs reportados como issues: no se detectaron bugs en la ejecucion (18/18 specs pasando, 0 fallos), por lo que no habia issues a abrir.

- Coordinacion con el Desarrollador JavaScript: no fue necesaria ya que el codigo de script.js resulto directamente testeable sin modificaciones (18/18 specs pasando con 0 fallos).