### PR TITLE
fix: mueve script embebido del modal a script.js y lo integra en DOMContentLoaded (RC19)

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,19 +549,7 @@
 
   </div>
 </div>
-<script>
-document.querySelector("#modalCompartir .btn-primary")
-.addEventListener("click", function() {
-    const input = document.querySelector("#modalCompartir input");
-    input.select();
-    input.setSelectionRange(0, 99999);
-
-    navigator.clipboard.writeText(input.value);
-
-    this.innerText = "Copiado!";
-    setTimeout(() => this.innerText = "Copiar enlace", 2000);
-});
-</script> 
+ 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/script.js"></script>
 </body>

--- a/js/script.js
+++ b/js/script.js
@@ -683,6 +683,19 @@ if (typeof window !== "undefined") {
  
   // Inicia el menú principal al cargar el documento
   window.addEventListener("DOMContentLoaded", function () {
+    // Lógica del modal compartir
+    const btnCopiar = document.querySelector("#modalCompartir .btn-primary");
+    if (btnCopiar) {
+      btnCopiar.addEventListener("click", function () {
+        const input = document.querySelector("#modalCompartir input");
+        input.select();
+        input.setSelectionRange(0, 99999);
+        navigator.clipboard.writeText(input.value);
+        this.innerText = "Copiado!";
+        setTimeout(() => this.innerText = "Copiar enlace", 2000);
+      });
+    }
+
     mostrarMenuPrincipal();
   });
 }


### PR DESCRIPTION
## Descripción
Correcciones RC19 y RC20 del rol Desarrollador JavaScript.

## Cambios realizados

- **index.html**: Se elimina el bloque `<script>` embebido con la lógica del botón "Copiar enlace" del modal compartir
- **js/script.js**: Se mueve la lógica del modal al bloque `DOMContentLoaded` junto con `mostrarMenuPrincipal()`, manteniendo todo el JS en un único archivo externo

## Motivo
RC19 — No debe existir JS embebido en HTML, debe estar en script.js
RC20 — El bloque `window.Planix` se mantiene para exposición de funciones a Jasmine

## Issue relacionada
Closes #92

## Tipo de cambio
- [x] fix (corrección de código)

## Checklist
- [x] Script del modal eliminado de index.html
- [x] Lógica del modal movida a script.js dentro de DOMContentLoaded