### PR TITLE
[Actividad Obligatoria N°4] Implementación de capa Storage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,14 +8,16 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ---
 
-## [Release Actividad Obligatoria N° 3] 2026-05-18
-
-### Added
+## [Release Actividad Obligatoria N° 4] 2026-06-15
 
 - [feature/dev-storage] Se agrega la capa de abstracción para `localStorage` y `sessionStorage` mediante `js/utils/storage.js`, y documentación de estrategia en `docs/06-storage/storage-doc.md`.  
 PR: [#106](https://github.com/martindebenedetti/Planix/pull/106) — @leanlex (Desarrollador JS Storage) — Issue: [#105](https://github.com/martindebenedetti/Planix/issues/105)
 
----
+### Fixed
+
+## [Release Actividad Obligatoria N° 3] 2026-05-18
+
+### Added
 
 - [feature/coord-cierre-etapa] Se actualiza `spec-devops.md` con cierre de Actividad, se actualiza `plan.md` y `README.md`. PR: [#89](https://github.com/martindebenedetti/Planix/pull/89) — @giann98 (Coordinador / DevOps) — Issue: #83
 
@@ -28,6 +30,8 @@ PR: [#106](https://github.com/martindebenedetti/Planix/pull/106) — @leanlex (D
 - [feature/coord-devops-tercera-entrega] Se documenta la carga de la PR Feature/coord devops tercera entrega, se carga el spec-devops.md. PR: [#84](https://github.com/martindebenedetti/Planix/pull/84) — @martindebenedetti (Arquitecto de Diagrama de Actividades) Ayudando al rol(Coordinador / DevOps) — Issue: #83
 
 ### Fixed
+
+---
 
 - [fix/RCN1-ui-test-spies] RCN1 Se realiza cambios en los documentos de test y se vuelve a ejecutar la suite de Jasmine con 43 casos, agregando los spies PR: [#103] (https://github.com/martindebenedetti/Planix/pull/103) — @giann98 (Tester JavaScript)
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Added
 
+- [feature/dev-storage] Se agrega la capa de abstracción para `localStorage` y `sessionStorage` mediante `js/utils/storage.js`, y documentación de estrategia en `docs/06-storage/storage-doc.md`.  
+PR: [#106](https://github.com/martindebenedetti/Planix/pull/106) — @leanlex (Desarrollador JS Storage) — Issue: [#105](https://github.com/martindebenedetti/Planix/issues/105)
+
+---
+
 - [feature/coord-cierre-etapa] Se actualiza `spec-devops.md` con cierre de Actividad, se actualiza `plan.md` y `README.md`. PR: [#89](https://github.com/martindebenedetti/Planix/pull/89) — @giann98 (Coordinador / DevOps) — Issue: #83
 
 - [feature/tester-javascript-jasmine] Se agrega `spec-tester.md` y completa con la realización de los test. Se crean archivos `js/test/script.spec.js`, `js/test/test-runner.html`, `js/test/testing-doc.md` y las capturas en `js/test/screenshots/`. PR: [#88](https://github.com/martindebenedetti/Planix/pull/88) — @giann98 (Tester QA)

--- a/docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md
+++ b/docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md
@@ -1,0 +1,197 @@
+# Spec - Desarrollador JS Storage
+
+## Actividad Obligatoria N°4 - Programación Web I
+
+## Rol
+
+Desarrollador JS Local y Session Storage.
+
+---
+
+## BEFORE - Plan inicial
+
+### Objetivo del rol
+
+Implementar una capa de abstracción para el uso de `localStorage` y `sessionStorage`, separando la lógica de persistencia del resto de la aplicación.
+
+El módulo de Storage deberá permitir guardar, obtener, actualizar, eliminar, listar y limpiar datos de manera reutilizable, sin manipular el DOM ni contener lógica visual.
+
+---
+
+### Archivos previstos
+
+- `docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md`
+- `js/utils/storage.js`
+- `docs/06-storage/storage-doc.md`
+
+---
+
+### Estrategia inicial de almacenamiento
+
+#### localStorage
+
+Se utilizará para datos que deben persistir entre sesiones del navegador, por ejemplo:
+
+- proyectos creados;
+- tareas asociadas a proyectos;
+- responsables o datos vinculados a la planificación;
+- preferencias persistentes de la aplicación.
+
+Justificación: estos datos forman parte del estado principal del proyecto y deberían conservarse aunque el usuario cierre o recargue el navegador.
+
+#### sessionStorage
+
+Se utilizará para datos temporales de la sesión actual, por ejemplo:
+
+- filtros activos;
+- vista o sección activa;
+- flujo seleccionado por el usuario;
+- mensajes o estados temporales de uso.
+
+Justificación: estos datos ayudan a mantener la experiencia durante la sesión, pero no necesariamente deben persistir cuando el usuario cierra el navegador.
+
+---
+
+### Convención preliminar de claves
+
+Se utilizará una convención de claves con prefijo del proyecto para evitar colisiones con otras aplicaciones:
+
+```text
+planix:proyectos
+planix:tareas
+planix:responsables
+planix:preferencias
+planix:sesion:filtros
+planix:sesion:vista-activa
+planix:sesion:flujo-activo
+```
+
+Criterio general:
+
+```text
+planix:<modulo>:<dato>
+planix:sesion:<dato-temporal>
+```
+
+---
+
+### Estructura preliminar de datos JSON
+
+#### Proyecto
+
+```json
+{
+  "id": "proyecto-1",
+  "nombre": "Proyecto ejemplo",
+  "fechaInicio": "2026-06-01",
+  "fechaFin": "2026-06-30",
+  "tareas": []
+}
+```
+
+#### Tarea
+
+```json
+{
+  "id": "tarea-1",
+  "nombre": "Diseñar interfaz",
+  "fechaInicio": "2026-06-01",
+  "fechaFin": "2026-06-05",
+  "avance": 50,
+  "responsable": "Leandro"
+}
+```
+
+#### Preferencias
+
+```json
+{
+  "vistaActiva": "gantt",
+  "mostrarCompletadas": true
+}
+```
+
+---
+
+### Funciones previstas en `js/utils/storage.js`
+
+- `guardar(clave, valor, tipo)`
+- `obtener(clave, tipo)`
+- `actualizar(clave, valor, tipo)`
+- `eliminar(clave, tipo)`
+- `listar(prefijo, tipo)`
+- `limpiar(tipo)`
+
+Donde `tipo` podrá recibir:
+
+- `local`: para utilizar `localStorage`;
+- `session`: para utilizar `sessionStorage`.
+
+---
+
+### Criterios de aceptación
+
+- [ ] El archivo `spec-dev-storage.md` fue creado y commiteado antes de `js/utils/storage.js`.
+- [ ] Existe el archivo `js/utils/storage.js`.
+- [ ] Se implementan funciones CRUD completas.
+- [ ] Todas las operaciones tienen manejo de errores con `try-catch`.
+- [ ] Se implementa serialización y deserialización automática con JSON.
+- [ ] Se documenta la estrategia en `docs/06-storage/storage-doc.md`.
+- [ ] El código no manipula DOM ni contiene lógica visual.
+- [ ] El módulo puede ser probado desde Jasmine.
+- [ ] La implementación puede integrarse con clases del dominio mediante `toJSON()` y `fromJSON()`.
+
+---
+
+## Uso de Copilot Agent Mode
+
+Pendiente de completar al cerrar la tarea.
+
+Al finalizar la implementación se deberá documentar:
+
+- prompt exacto utilizado;
+- archivos adjuntados como contexto;
+- output o fragmento generado por Copilot;
+- ajustes manuales realizados;
+- justificación técnica de los cambios.
+
+---
+
+## AT CLOSE - Evidencia final
+
+Pendiente de completar luego de implementar y revisar la funcionalidad.
+
+### Prompt utilizado en Copilot Agent Mode
+
+```text
+Pendiente de completar.
+```
+
+### Archivos adjuntados como contexto
+
+- Pendiente de completar.
+
+### Fragmento de código generado por Copilot
+
+```js
+// Pendiente de completar.
+```
+
+### Ajustes manuales realizados
+
+Pendiente de completar.
+
+### Decisiones finales de Storage
+
+Pendiente de completar.
+
+### Coordinación con Desarrollador JS POO
+
+Pendiente de completar.
+
+### Resultado final
+
+- [ ] `storage.js` implementado.
+- [ ] `storage-doc.md` documentado.
+- [ ] Funciones CRUD probadas.
+- [ ] Integración prevista con modelos POO.

--- a/docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md
+++ b/docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md
@@ -159,39 +159,108 @@ Al finalizar la implementación se deberá documentar:
 
 ## AT CLOSE - Evidencia final
 
-Pendiente de completar luego de implementar y revisar la funcionalidad.
-
 ### Prompt utilizado en Copilot Agent Mode
 
+Archivos adjuntados como contexto:
+
+- `docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md`
+- `js/utils/storage.js`
+- `docs/06-storage/storage-doc.md`
+
+Prompt utilizado:
+
 ```text
-Pendiente de completar.
+Revisá la implementación de la capa de Storage para la Actividad Obligatoria N°4 del proyecto Planix.
+
+Contexto:
+- El archivo js/utils/storage.js debe funcionar como capa de abstracción para localStorage y sessionStorage.
+- Debe implementar operaciones CRUD completas: guardar, obtener, actualizar, eliminar, listar y limpiar.
+- Debe usar serialización/deserialización JSON.
+- Debe manejar errores con try-catch.
+- No debe manipular DOM ni contener lógica visual.
+- El proyecto actualmente carga scripts tradicionales desde index.html, por eso StorageUtil se expone en window para facilitar integración con script.js y tests Jasmine.
+
+Tareas:
+1. Verificar si js/utils/storage.js cumple con la consigna.
+2. Indicar si falta alguna validación o mejora.
+3. Revisar si la documentación docs/06-storage/storage-doc.md es coherente con el código.
+4. Sugerir ajustes mínimos sin modificar la arquitectura actual.
+5. Devolver un resumen breve para documentar en spec-dev-storage.md.
 ```
 
-### Archivos adjuntados como contexto
+### Output generado por Copilot Agent
 
-- Pendiente de completar.
+Copilot Agent revisó `storage.js`, `storage-doc.md` y `spec-dev-storage.md`.
 
-### Fragmento de código generado por Copilot
+Indicó que la implementación cumple con los criterios principales del rol Storage:
+
+- implementa operaciones CRUD mediante `guardar`, `obtener`, `actualizar`, `eliminar`, `listar` y `limpiar`;
+- utiliza `JSON.stringify()` y `JSON.parse()` para serialización y deserialización;
+- incluye manejo de errores con `try-catch`;
+- no manipula DOM ni contiene lógica visual;
+- expone `StorageUtil` en `window` para compatibilidad con scripts tradicionales y tests Jasmine.
+
+También recomendó mejoras mínimas sin modificar la arquitectura:
+
+- validar que la clave sea una cadena no vacía;
+- normalizar el parámetro `tipo`, aceptando solo `local` o `session`;
+- agregar una función `existe(clave, tipo)` para facilitar validaciones y tests;
+- agregar una función `limpiarPorPrefijo(prefijo, tipo)` para eliminar solo claves del proyecto y evitar el uso destructivo de `clear()`;
+- documentar que `guardar()` puede fallar ante valores no serializables en JSON.
+
+### Fragmento de código revisado y ajustado
 
 ```js
-// Pendiente de completar.
+const StorageUtil = {
+  guardar,
+  obtener,
+  actualizar,
+  eliminar,
+  existe,
+  listar,
+  limpiar,
+  limpiarPorPrefijo
+};
+
+if (typeof window !== "undefined") {
+  window.StorageUtil = StorageUtil;
+}
 ```
 
 ### Ajustes manuales realizados
 
-Pendiente de completar.
+A partir de la revisión de Copilot Agent se aplicaron los siguientes ajustes manuales en `js/utils/storage.js`:
 
-### Decisiones finales de Storage
+- se agregó `validarClave(clave)` para evitar operaciones con claves vacías, indefinidas o inválidas;
+- se agregó `normalizarTipo(tipo)` para aceptar únicamente `local` o `session`;
+- se ajustó `obtenerStorage(tipo)` para devolver `null` si el tipo de storage no es válido;
+- se agregó `existe(clave, tipo)` para verificar la existencia de claves;
+- se agregó `limpiarPorPrefijo(prefijo, tipo)` para eliminar únicamente claves asociadas al prefijo del proyecto;
+- se mantuvo `limpiar(tipo)` como operación general, documentando que debe usarse con precaución;
+- se mantuvo la exposición global `window.StorageUtil` para no modificar todavía `index.html` a `type="module"`.
 
-Pendiente de completar.
+### Decisiones finales sobre la estrategia de Storage
+
+- `localStorage` se reserva para datos persistentes del proyecto, como proyectos, tareas y preferencias.
+- `sessionStorage` se reserva para datos temporales, como filtros, vista activa o estado de navegación.
+- Las claves del proyecto usan el prefijo `planix:`.
+- El módulo no depende del DOM ni de la interfaz.
+- La capa de Storage queda preparada para integrarse con futuras clases del dominio mediante objetos serializables.
+- La integración final con clases POO se realizará cuando existan los modelos en `js/models/`.
 
 ### Coordinación con Desarrollador JS POO
 
-Pendiente de completar.
+La capa Storage queda preparada para persistir objetos planos generados por futuras clases del dominio. Cuando se implementen clases como `Proyecto` o `Tarea`, se podrán guardar objetos mediante `toJSON()` y reconstruir instancias mediante métodos estáticos como `fromJSON()`.
 
-### Resultado final
+### Checklist de cierre
 
-- [ ] `storage.js` implementado.
-- [ ] `storage-doc.md` documentado.
-- [ ] Funciones CRUD probadas.
-- [ ] Integración prevista con modelos POO.
+- [x] El archivo `spec-dev-storage.md` fue creado y commiteado antes de `js/utils/storage.js`.
+- [x] Existe el archivo `js/utils/storage.js`.
+- [x] Se implementan funciones CRUD completas.
+- [x] Todas las operaciones tienen manejo de errores con `try-catch`.
+- [x] Se implementa serialización y deserialización automática con JSON.
+- [x] Se documenta la estrategia en `docs/06-storage/storage-doc.md`.
+- [x] El código no manipula DOM ni contiene lógica visual.
+- [x] El módulo queda preparado para ser probado desde Jasmine.
+- [x] Se aplicaron mejoras mínimas sugeridas por Copilot Agent.
+- [x] Se incorporaron `existe()` y `limpiarPorPrefijo()`.

--- a/docs/06-storage/storage-doc.md
+++ b/docs/06-storage/storage-doc.md
@@ -153,6 +153,8 @@ StorageUtil.limpiar("session");
 
 Elimina solamente las claves que comienzan con un prefijo determinado. Es una alternativa más segura que `limpiar()`, porque evita borrar información ajena al proyecto.
 
+Por seguridad, esta función rechaza prefijos vacíos. Para limpiar completamente el storage indicado, se debe usar `limpiar(tipo)`.
+
 ```js
 StorageUtil.limpiarPorPrefijo("planix:", "local");
 ```
@@ -165,6 +167,40 @@ El módulo utiliza:
 - `JSON.parse()` para recuperar datos complejos.
 
 Esto permite almacenar estructuras como proyectos, tareas, filtros y configuraciones.
+
+## Limitaciones de serialización
+
+El módulo utiliza JSON para persistir datos. Por ese motivo, no puede persistir correctamente ciertos valores.
+
+No se pueden guardar como valor principal:
+
+- valores `undefined`;
+- funciones;
+- símbolos (`Symbol`);
+- objetos con referencias circulares;
+- métodos de instancia.
+
+Para persistir instancias de clases, se recomienda convertirlas previamente a objetos planos mediante métodos como `toJSON()`.
+
+Ejemplo incorrecto:
+
+```js
+StorageUtil.guardar("planix:datos", {
+  id: 1,
+  handler: () => {}
+}, "local");
+```
+
+Ejemplo correcto:
+
+```js
+StorageUtil.guardar("planix:datos", {
+  id: 1,
+  nombre: "Proyecto"
+}, "local");
+```
+
+Si el valor no puede serializarse correctamente, la función `guardar()` retorna `false`.
 
 ## Manejo de errores
 

--- a/docs/06-storage/storage-doc.md
+++ b/docs/06-storage/storage-doc.md
@@ -1,0 +1,221 @@
+# Documentación de Storage - Planix
+
+## Actividad Obligatoria N°4
+
+## Objetivo
+
+Implementar una capa de abstracción para manejar `localStorage` y `sessionStorage` desde un único módulo reutilizable.
+
+El archivo principal es:
+
+```text
+js/utils/storage.js
+```
+
+## Estrategia de almacenamiento
+
+### localStorage
+
+Se utilizará para datos que deben persistir entre sesiones del navegador.
+
+Ejemplos previstos:
+
+- proyectos creados por el usuario;
+- tareas asociadas a un proyecto;
+- preferencias persistentes de la aplicación.
+
+### sessionStorage
+
+Se utilizará para datos temporales de la sesión actual.
+
+Ejemplos previstos:
+
+- filtros activos;
+- vista seleccionada;
+- estado temporal de la interfaz.
+
+## Convención de claves
+
+Se adopta el prefijo general:
+
+```text
+planix:
+```
+
+Ejemplos de claves:
+
+```text
+planix:proyectos
+planix:tareas
+planix:preferencias
+planix:sesion:filtros
+planix:sesion:vista-activa
+```
+
+## Estructura de datos prevista
+
+### Proyecto
+
+```json
+{
+  "id": 1,
+  "nombre": "Planificador Gantt",
+  "fechaInicio": "2026-03-01",
+  "fechaFin": "2026-05-05",
+  "tareas": []
+}
+```
+
+### Tarea
+
+```json
+{
+  "id": "1.1",
+  "nombre": "Relevamiento de requisitos",
+  "fechaInicio": "2026-03-01",
+  "fechaFin": "2026-03-10",
+  "responsable": "Leandro B.",
+  "predecesora": null,
+  "avance": 100,
+  "estado": "completada"
+}
+```
+
+### Filtros de sesión
+
+```json
+{
+  "responsable": "Leandro B.",
+  "estado": "en curso",
+  "vistaActiva": "gantt"
+}
+```
+
+## Funciones implementadas
+
+### guardar(clave, valor, tipo)
+
+Guarda un dato en `localStorage` o `sessionStorage`.
+
+```js
+StorageUtil.guardar("planix:proyectos", proyectos, "local");
+```
+
+### obtener(clave, tipo)
+
+Recupera un dato desde `localStorage` o `sessionStorage`.
+
+```js
+const proyectos = StorageUtil.obtener("planix:proyectos", "local");
+```
+
+### actualizar(clave, valor, tipo)
+
+Actualiza un dato existente. Si la clave no existe, la crea.
+
+```js
+StorageUtil.actualizar("planix:proyectos", proyectosActualizados, "local");
+```
+
+### eliminar(clave, tipo)
+
+Elimina una clave específica.
+
+```js
+StorageUtil.eliminar("planix:sesion:filtros", "session");
+```
+
+### existe(clave, tipo)
+
+Verifica si una clave existe en `localStorage` o `sessionStorage`.
+
+```js
+const existeProyecto = StorageUtil.existe("planix:proyectos", "local");
+```
+
+### listar(prefijo, tipo)
+
+Lista todas las claves que empiezan con un prefijo determinado.
+
+```js
+const claves = StorageUtil.listar("planix:", "local");
+```
+
+### limpiar(tipo)
+
+Limpia completamente el storage indicado.
+
+```js
+StorageUtil.limpiar("session");
+```
+
+### limpiarPorPrefijo(prefijo, tipo)
+
+Elimina solamente las claves que comienzan con un prefijo determinado. Es una alternativa más segura que `limpiar()`, porque evita borrar información ajena al proyecto.
+
+```js
+StorageUtil.limpiarPorPrefijo("planix:", "local");
+```
+
+## Serialización JSON
+
+El módulo utiliza:
+
+- `JSON.stringify()` para guardar objetos y arrays;
+- `JSON.parse()` para recuperar datos complejos.
+
+Esto permite almacenar estructuras como proyectos, tareas, filtros y configuraciones.
+
+## Manejo de errores
+
+Todas las operaciones principales utilizan `try-catch`.
+
+Se contemplan errores como:
+
+- storage no disponible;
+- datos corruptos;
+- JSON mal formado;
+- problemas al guardar o recuperar información;
+- claves inexistentes.
+
+## Diferencia entre localStorage y sessionStorage en el proyecto
+
+| Tipo de storage | Uso previsto | Persistencia |
+|---|---|---|
+| `localStorage` | Proyectos, tareas y preferencias generales | Permanece entre sesiones |
+| `sessionStorage` | Filtros, vista activa y datos temporales de navegación | Se borra al cerrar la pestaña o navegador |
+
+## Integración prevista
+
+Este módulo no manipula el DOM ni contiene lógica visual.
+
+La integración final será realizada desde el controlador principal `js/script.js` o desde los módulos que correspondan en la arquitectura de la Actividad Obligatoria N°4.
+
+## Relación con POO
+
+Cuando estén implementadas las clases del dominio en `js/models/`, el módulo de storage podrá persistir objetos serializados mediante métodos como:
+
+```js
+const proyectoPlano = proyecto.toJSON();
+StorageUtil.guardar("planix:proyectos", [proyectoPlano], "local");
+```
+
+Y luego reconstruir instancias mediante métodos estáticos como:
+
+```js
+const proyectosGuardados = StorageUtil.obtener("planix:proyectos", "local");
+const proyectos = proyectosGuardados.map((item) => Proyecto.fromJSON(item));
+```
+
+## Estado
+
+- [x] Capa de abstracción creada.
+- [x] CRUD básico implementado.
+- [x] Serialización JSON implementada.
+- [x] Manejo de errores implementado.
+- [x] Documentación inicial de estrategia de storage creada.
+- [ ] Integración final con clases POO.
+- [ ] Tests automatizados desde Jasmine.
+- [x] Validación de claves implementada.
+- [x] Normalización del tipo de storage implementada.
+- [x] Funciones auxiliares `existe()` y `limpiarPorPrefijo()` implementadas.

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -8,6 +8,8 @@
 
 /**
  * Valida que la clave sea una cadena no vacía.
+ * Los espacios iniciales y finales se ignoran mediante trim().
+ *
  * @param {string} clave - Clave a validar.
  * @returns {boolean} true si la clave es válida, false en caso contrario.
  */
@@ -46,8 +48,16 @@ function obtenerStorage(tipo = "local") {
 
 /**
  * Guarda un valor en localStorage o sessionStorage.
+ *
+ * Limitaciones de serialización:
+ * - No se pueden persistir valores undefined.
+ * - No se pueden persistir funciones.
+ * - No se pueden persistir símbolos (Symbol) como valor principal.
+ * - No se pueden persistir objetos con referencias circulares.
+ * - Para instancias de clases, se recomienda convertirlas previamente a objetos planos con toJSON().
+ *
  * @param {string} clave - Clave donde se guardará el dato.
- * @param {*} valor - Valor a guardar.
+ * @param {*} valor - Valor a guardar. Debe ser serializable a JSON.
  * @param {string} tipo - Tipo de storage: "local" o "session".
  * @returns {boolean} true si se guardó correctamente, false si ocurrió un error.
  */
@@ -67,7 +77,9 @@ function guardar(clave, valor, tipo = "local") {
     const valorSerializado = JSON.stringify(valor);
 
     if (valorSerializado === undefined) {
-      console.error("No se puede guardar un valor no serializable en JSON.");
+      console.error(
+        "No se puede guardar el valor en storage: undefined, funciones y símbolos no son serializables como valor principal en JSON."
+      );
       return false;
     }
 
@@ -232,7 +244,11 @@ function limpiar(tipo = "local") {
 /**
  * Elimina únicamente las claves que comienzan con un prefijo determinado.
  * Es una alternativa más segura que limpiar(), porque no borra datos ajenos al proyecto.
- * @param {string} prefijo - Prefijo de claves a eliminar.
+ *
+ * Importante: esta función rechaza prefijos vacíos como medida de seguridad.
+ * Para limpiar completamente el storage indicado, usar limpiar(tipo).
+ *
+ * @param {string} prefijo - Prefijo de claves a eliminar. No puede ser vacío.
  * @param {string} tipo - Tipo de storage: "local" o "session".
  * @returns {boolean} true si se eliminaron correctamente, false si ocurrió un error.
  */

--- a/js/utils/storage.js
+++ b/js/utils/storage.js
@@ -1,0 +1,285 @@
+/**
+ * Módulo de utilidades para manejar localStorage y sessionStorage.
+ * Centraliza operaciones CRUD, serialización JSON y manejo básico de errores.
+ *
+ * Actividad Obligatoria N°4 - Programación Web I
+ * Proyecto: Planix
+ */
+
+/**
+ * Valida que la clave sea una cadena no vacía.
+ * @param {string} clave - Clave a validar.
+ * @returns {boolean} true si la clave es válida, false en caso contrario.
+ */
+function validarClave(clave) {
+  return typeof clave === "string" && clave.trim().length > 0;
+}
+
+/**
+ * Normaliza el tipo de storage indicado.
+ * @param {string} tipo - "local" para localStorage o "session" para sessionStorage.
+ * @returns {string|null} "local", "session" o null si el tipo no es válido.
+ */
+function normalizarTipo(tipo = "local") {
+  if (tipo === "local" || tipo === "session") {
+    return tipo;
+  }
+
+  console.error("Tipo de storage inválido. Usar 'local' o 'session'.");
+  return null;
+}
+
+/**
+ * Obtiene el storage correspondiente según el tipo indicado.
+ * @param {string} tipo - "local" para localStorage o "session" para sessionStorage.
+ * @returns {Storage|null} Objeto Storage seleccionado o null si el tipo es inválido.
+ */
+function obtenerStorage(tipo = "local") {
+  const tipoNormalizado = normalizarTipo(tipo);
+
+  if (tipoNormalizado === null) {
+    return null;
+  }
+
+  return tipoNormalizado === "session" ? sessionStorage : localStorage;
+}
+
+/**
+ * Guarda un valor en localStorage o sessionStorage.
+ * @param {string} clave - Clave donde se guardará el dato.
+ * @param {*} valor - Valor a guardar.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {boolean} true si se guardó correctamente, false si ocurrió un error.
+ */
+function guardar(clave, valor, tipo = "local") {
+  try {
+    if (!validarClave(clave)) {
+      console.error("Clave inválida para guardar en storage.");
+      return false;
+    }
+
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return false;
+    }
+
+    const valorSerializado = JSON.stringify(valor);
+
+    if (valorSerializado === undefined) {
+      console.error("No se puede guardar un valor no serializable en JSON.");
+      return false;
+    }
+
+    storage.setItem(clave, valorSerializado);
+    return true;
+  } catch (error) {
+    console.error("Error al guardar en storage:", error);
+    return false;
+  }
+}
+
+/**
+ * Obtiene un valor desde localStorage o sessionStorage.
+ * @param {string} clave - Clave del dato a recuperar.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {*} Valor recuperado o null si no existe o si ocurre un error.
+ */
+function obtener(clave, tipo = "local") {
+  try {
+    if (!validarClave(clave)) {
+      console.error("Clave inválida para obtener desde storage.");
+      return null;
+    }
+
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return null;
+    }
+
+    const valor = storage.getItem(clave);
+
+    if (valor === null) {
+      return null;
+    }
+
+    return JSON.parse(valor);
+  } catch (error) {
+    console.error("Error al obtener desde storage:", error);
+    return null;
+  }
+}
+
+/**
+ * Actualiza un valor existente en localStorage o sessionStorage.
+ * Si la clave no existe, la crea.
+ * @param {string} clave - Clave del dato a actualizar.
+ * @param {*} valor - Nuevo valor.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {boolean} true si se actualizó correctamente, false si ocurrió un error.
+ */
+function actualizar(clave, valor, tipo = "local") {
+  return guardar(clave, valor, tipo);
+}
+
+/**
+ * Elimina un valor desde localStorage o sessionStorage.
+ * @param {string} clave - Clave del dato a eliminar.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {boolean} true si se eliminó correctamente, false si ocurrió un error.
+ */
+function eliminar(clave, tipo = "local") {
+  try {
+    if (!validarClave(clave)) {
+      console.error("Clave inválida para eliminar desde storage.");
+      return false;
+    }
+
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return false;
+    }
+
+    storage.removeItem(clave);
+    return true;
+  } catch (error) {
+    console.error("Error al eliminar desde storage:", error);
+    return false;
+  }
+}
+
+/**
+ * Verifica si existe una clave en localStorage o sessionStorage.
+ * @param {string} clave - Clave del dato a verificar.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {boolean} true si la clave existe, false en caso contrario.
+ */
+function existe(clave, tipo = "local") {
+  try {
+    if (!validarClave(clave)) {
+      return false;
+    }
+
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return false;
+    }
+
+    return storage.getItem(clave) !== null;
+  } catch (error) {
+    console.error("Error al verificar existencia en storage:", error);
+    return false;
+  }
+}
+
+/**
+ * Lista las claves almacenadas que comienzan con un prefijo determinado.
+ * @param {string} prefijo - Prefijo de claves a buscar.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {Array<string>} Lista de claves encontradas.
+ */
+function listar(prefijo = "", tipo = "local") {
+  try {
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return [];
+    }
+
+    const prefijoNormalizado = typeof prefijo === "string" ? prefijo : "";
+    const claves = [];
+
+    for (let i = 0; i < storage.length; i++) {
+      const clave = storage.key(i);
+
+      if (clave && clave.startsWith(prefijoNormalizado)) {
+        claves.push(clave);
+      }
+    }
+
+    return claves;
+  } catch (error) {
+    console.error("Error al listar claves de storage:", error);
+    return [];
+  }
+}
+
+/**
+ * Limpia completamente localStorage o sessionStorage.
+ * Usar con precaución porque elimina todas las claves del storage indicado.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {boolean} true si se limpió correctamente, false si ocurrió un error.
+ */
+function limpiar(tipo = "local") {
+  try {
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return false;
+    }
+
+    storage.clear();
+    return true;
+  } catch (error) {
+    console.error("Error al limpiar storage:", error);
+    return false;
+  }
+}
+
+/**
+ * Elimina únicamente las claves que comienzan con un prefijo determinado.
+ * Es una alternativa más segura que limpiar(), porque no borra datos ajenos al proyecto.
+ * @param {string} prefijo - Prefijo de claves a eliminar.
+ * @param {string} tipo - Tipo de storage: "local" o "session".
+ * @returns {boolean} true si se eliminaron correctamente, false si ocurrió un error.
+ */
+function limpiarPorPrefijo(prefijo, tipo = "local") {
+  try {
+    if (!validarClave(prefijo)) {
+      console.error("Prefijo inválido para limpiar storage.");
+      return false;
+    }
+
+    const storage = obtenerStorage(tipo);
+
+    if (storage === null) {
+      return false;
+    }
+
+    const claves = listar(prefijo, tipo);
+
+    claves.forEach((clave) => {
+      storage.removeItem(clave);
+    });
+
+    return true;
+  } catch (error) {
+    console.error("Error al limpiar claves por prefijo:", error);
+    return false;
+  }
+}
+
+/**
+ * API pública del módulo StorageUtil.
+ */
+const StorageUtil = {
+  guardar,
+  obtener,
+  actualizar,
+  eliminar,
+  existe,
+  listar,
+  limpiar,
+  limpiarPorPrefijo
+};
+
+/**
+ * Exposición global para integración con scripts tradicionales y tests Jasmine.
+ * Esto permite usar StorageUtil sin modificar todavía index.html a type="module".
+ */
+if (typeof window !== "undefined") {
+  window.StorageUtil = StorageUtil;
+}


### PR DESCRIPTION
# 🟣 PULL REQUEST – Actividad Obligatoria N.º 4 – Programación Web I

---

## 📌 Datos del Estudiante

- **Nombre y Apellido:** Leandro Berro  
- **Número de Matrícula:** 155667  
- **Carrera:** Tecnicatura Universitaria en Programación de Sistemas  
- **Materia:** Programación Web I  
- **Profesor:** Lic. Matías Velasquez  
- **Cuatrimestre/Año:** 1º Cuatrimestre / 2026  
- **Rol asignado para esta entrega:** Desarrollador JS Local y Session Storage  

---

## 📂 Rama de trabajo

- **Nombre de la rama:** `feature/dev-storage`
- **Rama base:** `develop`

---

## 📝 Descripción del trabajo realizado

En esta rama se desarrolló la parte correspondiente al rol **Desarrollador JS Local y Session Storage** para la Actividad Obligatoria N.º 4.

El objetivo principal fue implementar una capa de abstracción para el manejo de `localStorage` y `sessionStorage`, separando la lógica de persistencia del resto de la aplicación.

Las tareas principales realizadas fueron:

- creación previa de `spec-dev-storage.md`, siguiendo el flujo de trabajo en dos momentos solicitado por la consigna;
- definición de la estrategia de almacenamiento para `localStorage` y `sessionStorage`;
- diseño de una convención de claves con prefijo `planix:`;
- creación del módulo `js/utils/storage.js`;
- implementación de operaciones CRUD para Storage;
- incorporación de manejo de errores mediante `try-catch`;
- incorporación de serialización y deserialización automática mediante JSON;
- agregado de funciones auxiliares como `existe()` y `limpiarPorPrefijo()`;
- documentación de la estrategia de almacenamiento en `docs/06-storage/storage-doc.md`;
- revisión de la implementación mediante GitHub Copilot Agent Mode y documentación del proceso en el spec.

El módulo queda preparado para integrarse posteriormente con las clases del dominio en `js/models/`, mediante métodos como `toJSON()` y `fromJSON()`.

---

## 📄 Archivos modificados / agregados

- `docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md`
- `js/utils/storage.js`
- `docs/06-storage/storage-doc.md`

---

## Issues alcanzados

Closes #105 

---

## ✅ Checklist

- [x] Trabajé sobre una rama `feature/` creada a partir de `develop`
- [x] Realicé commits claros y explicativos
- [x] Completé mi sección asignada según el rol
- [x] Creé y commiteé `spec-dev-storage.md` antes de implementar `js/utils/storage.js`
- [x] Utilicé GitHub Copilot Agent Mode y documenté el proceso en el spec
- [x] Implementé funciones CRUD para `localStorage` y `sessionStorage`
- [x] Implementé manejo de errores con `try-catch`
- [x] Implementé serialización/deserialización con JSON
- [x] Documenté la estrategia de almacenamiento en `docs/06-storage/storage-doc.md`
- [x] La PR incluye solo cambios relacionados con mi tarea asignada
- [x] Actualicé el archivo `changelog.md` con el resumen de esta PR

---

## 🧠 Comentarios adicionales

Se respetó el flujo de trabajo indicado para el rol Storage:

1. creación previa del archivo `spec-dev-storage.md`;
2. definición de estrategia de almacenamiento;
3. implementación de `js/utils/storage.js`;
4. documentación en `docs/06-storage/storage-doc.md`;
5. revisión con Copilot Agent Mode;
6. cierre del spec con evidencia, ajustes manuales y criterios cumplidos.

La integración final con el controlador principal y con las clases POO queda prevista para las ramas correspondientes de Eventos/DOM y POO.

---

## 🧾 Enlaces útiles

- [📄 README del proyecto](https://github.com/martindebenedetti/Planix/blob/develop/README.md)
- [📄 Spec Storage](https://github.com/martindebenedetti/Planix/blob/feature/dev-storage/docs/03-specs/actividad-obligatoria-4/spec-dev-storage.md)
- [📄 Documentación Storage](https://github.com/martindebenedetti/Planix/blob/feature/dev-storage/docs/06-storage/storage-doc.md)

---

## ⚠ IMPORTANTE

🚫 Sin esta Pull Request **no se justifica participación individual**.  
✅ Recordá que el `changelog.md` debe reflejar los cambios aprobados.