### PR TITLE
[RC1][Async] Manejo interno de errores en ApiService

### DIFF
--- a/js/api/apiService.js
+++ b/js/api/apiService.js
@@ -2,13 +2,17 @@ const ApiService = {
   baseUrl: "https://jsonplaceholder.typicode.com",
 
   async fetchData(endpoint) {
-    const response = await fetch(`${this.baseUrl}${endpoint}`);
+    try {
+      const response = await fetch(`${this.baseUrl}${endpoint}`);
 
-    if (!response.ok) {
-      throw new Error(`Error HTTP: ${response.status}`);
+      if (!response.ok) {
+        throw new Error(`Error HTTP: ${response.status}`);
+      }
+
+      return response.json();
+    } catch (error) {
+      throw new Error(`No se pudieron obtener datos de la API: ${error.message}`);
     }
-
-    return response.json();
   },
 
   async obtenerTodos(limite = 10) {
@@ -16,15 +20,19 @@ const ApiService = {
   },
 
   async eliminarTodo(id) {
-    const response = await fetch(`${this.baseUrl}/todos/${id}`, {
-      method: "DELETE"
-    });
+    try {
+      const response = await fetch(`${this.baseUrl}/todos/${id}`, {
+        method: "DELETE"
+      });
 
-    if (!response.ok) {
-      throw new Error(`No se pudo eliminar la tarea. Estado: ${response.status}`);
+      if (!response.ok) {
+        throw new Error(`No se pudo eliminar la tarea. Estado: ${response.status}`);
+      }
+
+      return true;
+    } catch (error) {
+      throw new Error(`Error al eliminar la tarea externa: ${error.message}`);
     }
-
-    return true;
   },
 
   validarTodo(todo) {

--- a/js/test/api.spec.js
+++ b/js/test/api.spec.js
@@ -32,14 +32,16 @@ describe("ApiService - Fetch & APIs", function () {
       ).toBeRejectedWithError(/Error HTTP: 404/);
     });
 
-    it("propaga errores de red al fallar fetch", async function () {
+    it("maneja errores de red al fallar fetch", async function () {
       spyOn(window, "fetch").and.returnValue(
         Promise.reject(new Error("Error de red"))
       );
 
-      await expectAsync(
-        ApiService.fetchData("/todos")
-      ).toBeRejectedWithError("Error de red");
+      await expectAsync(ApiService.fetchData("/todos"))
+        .toBeRejectedWithError(
+          Error,
+          "No se pudieron obtener datos de la API: Error de red"
+        );
     });
   });
 


### PR DESCRIPTION
## Corrección incluida

Se resuelve RC1 indicado por el docente.

## Observación del docente

`fetchData` y `eliminarTodo` lanzaban errores sin `try-catch` interno. Si fallaba la red, DNS, timeout o conexión, la excepción se propagaba sin ser capturada dentro del propio servicio.

## Cambios realizados

- Se agregó `try-catch` interno en `fetchData(endpoint)`.
- Se agregó `try-catch` interno en `eliminarTodo(id)`.
- Se mantienen errores HTTP controlados.
- Se relanzan mensajes amigables para que la UI pueda mostrarlos correctamente.
- Se actualizó el test de error de red para validar el nuevo mensaje controlado del servicio.

## Rama

`fix/rc1-api-service-errors` → `release/segundo-parcial`

## Issue

Closes #136 

## Validaciones

- [x] `node --check js/api/apiService.js`
- [x] `node --check js/test/api.spec.js`
- [x] `git diff --check`
- [x] Jasmine: `101 specs, 0 failures`

Coordinación Fase 2: @leanlex