### PR TITLE
Fix/library spec error validacion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/library-spec-error-validacion] Se resolvió un problema en un test dentro de library.spec.js.
+ PR: [#153](https://github.com/martindebenedetti/Planix/pull/153) — @giann98 (Tester QA/JS)
+
 - [fix/RC6-a-RC13-auditoria-y-fixes] Resolución integral de observaciones (RC6-RC13): implementación de casos de prueba asíncronos en Jasmine (error 500 y rechazo de promesas), normalización semántica de la tabla Gantt mediante aria-labels y visually-hidden, optimización de métricas Lighthouse (Mobile Performance y Accessibility 100/100), y refactorización de lógica de visibilidad en script.js Se reemplazaron estilos inline evitables por clases utilitarias de Bootstrap, manteniendo únicamente la mutación de ancho porcentual necesaria para la barra de progreso dinámica.
   PR: [#134](https://github.com/martindebenedetti/Planix/pull/134) — @giann98 (Tester QA/JS) — Issue: [#141](https://github.com/martindebenedetti/Planix/issues/141) — Issue: [#142](https://github.com/martindebenedetti/Planix/issues/142) — Issue: [#143](https://github.com/martindebenedetti/Planix/issues/143) — Issue: [#144](https://github.com/martindebenedetti/Planix/issues/144) — Issue: [#145](https://github.com/martindebenedetti/Planix/issues/145) — Issue: [#146](https://github.com/martindebenedetti/Planix/issues/146) — Issue: [#147](https://github.com/martindebenedetti/Planix/issues/147)
 

--- a/js/test/library.spec.js
+++ b/js/test/library.spec.js
@@ -22,7 +22,7 @@ describe("Notificaciones - Pruebas de Integración de Librería Externa (SweetAl
     it("debe configurar adecuadamente la estructura del modal ante eventos de error", function () {
       spyOn(Swal, "fire");
 
-      Notificaciones.error("Fallo de validación de campos");
+      Notificaciones.error("Ocurrió un error", "Fallo de validación de campos");
 
       expect(Swal.fire).toHaveBeenCalledWith(jasmine.objectContaining({
         icon: "error",


### PR DESCRIPTION
Se corrió la suite de test y se detectó un error en un test dentro de library.spec.js, se corrigió y se agregó lo faltante en el archivo. 
